### PR TITLE
Update to 2019.3.1 (2019.3.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian
 LABEL maintainer "Viktor Adam <rycus86@gmail.com>"
 
 ARG PYCHARM_VERSION=2019.3
-ARG PYCHARM_BUILD=2019.3
+ARG PYCHARM_BUILD=2019.3.1
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
   python python-dev python-setuptools python-pip \


### PR DESCRIPTION
Version bumped using https://github.com/rycus86/autobump